### PR TITLE
fix(yazi.toml): use i16 type to allow negative ints in offset x/y coords

### DIFF
--- a/schemas/types/i16.json
+++ b/schemas/types/i16.json
@@ -1,0 +1,7 @@
+{
+	"$id": "https://yazi-rs.github.io/schemas/types/u16.json",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "integer",
+	"minimum": -32768,
+	"maximum": 32767
+}

--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -255,9 +255,13 @@
 		},
 		"offset": {
 			"type": "array",
-			"items": {
-				"$ref": "/schemas/types/u16.json"
-			},
+			"items": false,
+			"prefixItems": [
+				{ "$ref": "/schemas/types/i16.json" },
+				{ "$ref": "/schemas/types/i16.json" },
+				{ "$ref": "/schemas/types/u16.json" },
+				{ "$ref": "/schemas/types/u16.json" }
+			],
 			"minItems": 4,
 			"maxItems": 4
 		}


### PR DESCRIPTION
Taplo is having trouble linting with this, which I think is because the JSON Schema validator library they are using doesn't support the 2020-12 draft yet.