### PR TITLE
feat: add prepend/append preloaders and previewers

### DIFF
--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -135,66 +135,12 @@
 		"plugin": {
 			"type": "object",
 			"properties": {
-				"preloaders": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"name": { "type": "string" },
-							"mime": { "type": "string" },
-							"run": { "type": "string" },
-							"exec": { "type": "string" },
-							"cond": { "type": "string" },
-							"multi": { "type": "boolean" },
-							"sync": { "type": "boolean" },
-							"prio": { "enum": ["low", "normal", "high"] }
-						},
-						"oneOf": [
-							{
-								"required": ["mime", "run"]
-							},
-							{
-								"required": ["name", "run"]
-							},
-							{
-								"required": ["mime", "exec"]
-							},
-							{
-								"required": ["name", "exec"]
-							}
-						]
-					}
-				},
-				"previewers": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"name": { "type": "string" },
-							"mime": { "type": "string" },
-							"run": { "type": "string" },
-							"exec": { "type": "string" },
-							"cond": { "type": "string" },
-							"multi": { "type": "boolean" },
-							"sync": { "type": "boolean" },
-							"prio": { "enum": ["low", "normal", "high"] }
-						},
-						"oneOf": [
-							{
-								"required": ["mime", "run"]
-							},
-							{
-								"required": ["name", "run"]
-							},
-							{
-								"required": ["mime", "exec"]
-							},
-							{
-								"required": ["name", "exec"]
-							}
-						]
-					}
-				}
+				"preloaders": { "$ref": "#/$defs/preloaders" },
+				"prepend_preloaders": { "$ref": "#/$defs/preloaders" },
+				"append_preloaders": { "$ref": "#/$defs/preloaders" },
+				"previewers": { "$ref": "#/$defs/previewers" },
+				"prepend_previewers": { "$ref": "#/$defs/previewers" },
+				"append_previewers": { "$ref": "#/$defs/previewers" }
 			},
 			"additionalProperties": false
 		},
@@ -345,6 +291,66 @@
 			},
 			"minItems": 4,
 			"maxItems": 4
+		},
+		"preloaders": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"mime": { "type": "string" },
+					"run": { "type": "string" },
+					"exec": { "type": "string" },
+					"cond": { "type": "string" },
+					"multi": { "type": "boolean" },
+					"sync": { "type": "boolean" },
+					"prio": { "enum": ["low", "normal", "high"] }
+				},
+				"oneOf": [
+					{
+						"required": ["mime", "run"]
+					},
+					{
+						"required": ["name", "run"]
+					},
+					{
+						"required": ["mime", "exec"]
+					},
+					{
+						"required": ["name", "exec"]
+					}
+				]
+			}
+		},
+		"previewers": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string" },
+					"mime": { "type": "string" },
+					"run": { "type": "string" },
+					"exec": { "type": "string" },
+					"cond": { "type": "string" },
+					"multi": { "type": "boolean" },
+					"sync": { "type": "boolean" },
+					"prio": { "enum": ["low", "normal", "high"] }
+				},
+				"oneOf": [
+					{
+						"required": ["mime", "run"]
+					},
+					{
+						"required": ["name", "run"]
+					},
+					{
+						"required": ["mime", "exec"]
+					},
+					{
+						"required": ["name", "exec"]
+					}
+				]
+			}
 		}
 	}
 }

--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -135,12 +135,12 @@
 		"plugin": {
 			"type": "object",
 			"properties": {
-				"preloaders": { "$ref": "#/$defs/preloaders" },
-				"prepend_preloaders": { "$ref": "#/$defs/preloaders" },
-				"append_preloaders": { "$ref": "#/$defs/preloaders" },
-				"previewers": { "$ref": "#/$defs/previewers" },
-				"prepend_previewers": { "$ref": "#/$defs/previewers" },
-				"append_previewers": { "$ref": "#/$defs/previewers" }
+				"preloaders": { "$ref": "#/$defs/preloaders_or_previewers" },
+				"prepend_preloaders": { "$ref": "#/$defs/preloaders_or_previewers" },
+				"append_preloaders": { "$ref": "#/$defs/preloaders_or_previewers" },
+				"previewers": { "$ref": "#/$defs/preloaders_or_previewers" },
+				"prepend_previewers": { "$ref": "#/$defs/preloaders_or_previewers" },
+				"append_previewers": { "$ref": "#/$defs/preloaders_or_previewers" }
 			},
 			"additionalProperties": false
 		},
@@ -292,37 +292,7 @@
 			"minItems": 4,
 			"maxItems": 4
 		},
-		"preloaders": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"name": { "type": "string" },
-					"mime": { "type": "string" },
-					"run": { "type": "string" },
-					"exec": { "type": "string" },
-					"cond": { "type": "string" },
-					"multi": { "type": "boolean" },
-					"sync": { "type": "boolean" },
-					"prio": { "enum": ["low", "normal", "high"] }
-				},
-				"oneOf": [
-					{
-						"required": ["mime", "run"]
-					},
-					{
-						"required": ["name", "run"]
-					},
-					{
-						"required": ["mime", "exec"]
-					},
-					{
-						"required": ["name", "exec"]
-					}
-				]
-			}
-		},
-		"previewers": {
+		"preloaders_or_previewers": {
 			"type": "array",
 			"items": {
 				"type": "object",


### PR DESCRIPTION
This PR adds the missing `prepend_preloaders`, `append_preloaders`, `prepend_previewers`, and `append_previewers` introduced in https://github.com/sxyazi/yazi/commit/93c8d90a519490cf3119d16341bf52860a4d9358 at Yazi 0.2.0.

