### PR TITLE
fix(schemas/yazi.json): add `append_rules` and `prepend_rules` to `open`

### DIFF
--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -91,31 +91,9 @@
 		"open": {
 			"type": "object",
 			"properties": {
-				"rules": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"mime": { "type": "string" },
-							"name": { "type": "string" },
-							"use": {
-								"oneOf": [
-									{ "type": "array", "items": { "type": "string" } },
-									{ "type": "string" }
-								]
-							}
-						},
-						"required": ["use"],
-						"oneOf": [
-							{
-								"required": ["mime"]
-							},
-							{
-								"required": ["name"]
-							}
-						]
-					}
-				}
+				"rules": { "$ref": "#/$defs/open_rules" },
+				"append_rules": { "$ref": "#/$defs/open_rules" },
+				"prepend_rules": { "$ref": "#/$defs/open_rules" }
 			},
 			"additionalProperties": false
 		},
@@ -356,6 +334,31 @@
 					},
 					{
 						"required": ["name", "run"]
+					}
+				]
+			}
+		},
+		"open_rules": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"mime": { "type": "string" },
+					"name": { "type": "string" },
+					"use": {
+						"oneOf": [
+							{ "type": "array", "items": { "type": "string" } },
+							{ "type": "string" }
+						]
+					}
+				},
+				"required": ["use"],
+				"oneOf": [
+					{
+						"required": ["mime"]
+					},
+					{
+						"required": ["name"]
 					}
 				]
 			}


### PR DESCRIPTION
Fixes #28

I did not add any tests since it seems that the script in `scripts/lint.js` only tests the preset configurations in yazi, and this rules wouldn't make sense in there. Maybe consider adding additional configs here for test purposes? Right now I tested it by modifying my local clone and it passed.