### PR TITLE
feat: update schemas and submodule for v0.3.2

### DIFF
--- a/schemas/keymap.json
+++ b/schemas/keymap.json
@@ -44,6 +44,15 @@
 			},
 			"additionalProperties": false
 		},
+		"confirm": {
+			"type": "object",
+			"properties": {
+				"keymap": { "$ref": "#/$defs/keymap" },
+				"prepend_keymap": { "$ref": "#/$defs/keymap" },
+				"append_keymap": { "$ref": "#/$defs/keymap" }
+			},
+			"additionalProperties": false
+		},
 		"completion": {
 			"type": "object",
 			"properties": {

--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -51,12 +51,12 @@
 		"preview": {
 			"type": "object",
 			"properties": {
-				"wrap": {"enum": ["yes", "no"]},
+				"wrap": { "enum": ["yes", "no"] },
 				"tab_size": { "$ref": "/schemas/types/u8.json" },
 				"max_width": { "$ref": "/schemas/types/u32.json" },
 				"max_height": { "$ref": "/schemas/types/u32.json" },
 				"cache_dir": { "type": "string" },
-				"image_delay": {"type": "number", "minimum": 0, "maximum": 100 },
+				"image_delay": { "type": "number", "minimum": 0, "maximum": 100 },
 				"image_filter": {
 					"enum": ["nearest", "triangle", "catmull-rom", "lanczos3"]
 				},
@@ -203,33 +203,33 @@
 			"properties": {
 				"trash_title": { "type": "string" },
 				"trash_origin": {
-					 "$ref": "#/$defs/origin"
-				},
-				"trash_offset": { 
-					"$ref": "#/$defs/offset" 
-				},
-				"delete_title": { "type": "string" },
-				"delete_origin": { 
 					"$ref": "#/$defs/origin"
 				},
-				"delete_offset": { 
-					"$ref": "#/$defs/offset" 
+				"trash_offset": {
+					"$ref": "#/$defs/offset"
+				},
+				"delete_title": { "type": "string" },
+				"delete_origin": {
+					"$ref": "#/$defs/origin"
+				},
+				"delete_offset": {
+					"$ref": "#/$defs/offset"
 				},
 				"overwrite_title": { "type": "string" },
 				"overwrite_content": { "type": "string" },
 				"overwrite_origin": {
-					"$ref": "#/$defs/origin" 
+					"$ref": "#/$defs/origin"
 				},
-				"overwrite_offset": { 
+				"overwrite_offset": {
 					"$ref": "#/$defs/offset"
-			  },
+				},
 				"quit_title": { "type": "string" },
 				"quit_content": { "type": "string" },
-				"quit_origin": { 
-					"$ref": "#/$defs/origin" 
+				"quit_origin": {
+					"$ref": "#/$defs/origin"
 				},
-				"quit_offset": { 
-					"$ref": "#/$defs/offset" 
+				"quit_offset": {
+					"$ref": "#/$defs/offset"
 				}
 			},
 			"additionalProperties": false

--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -43,17 +43,20 @@
 					"items": {
 						"enum": ["click", "scroll", "touch", "move", "drag"]
 					}
-				}
+				},
+				"title_format": { "type": "string" }
 			},
 			"additionalProperties": false
 		},
 		"preview": {
 			"type": "object",
 			"properties": {
+				"wrap": {"enum": ["yes", "no"]},
 				"tab_size": { "$ref": "/schemas/types/u8.json" },
 				"max_width": { "$ref": "/schemas/types/u32.json" },
 				"max_height": { "$ref": "/schemas/types/u32.json" },
 				"cache_dir": { "type": "string" },
+				"image_delay": {"type": "number", "minimum": 0, "maximum": 100 },
 				"image_filter": {
 					"enum": ["nearest", "triangle", "catmull-rom", "lanczos3"]
 				},
@@ -155,20 +158,6 @@
 				"rename_offset": {
 					"$ref": "#/$defs/offset"
 				},
-				"trash_title": { "type": "string" },
-				"trash_origin": {
-					"$ref": "#/$defs/origin"
-				},
-				"trash_offset": {
-					"$ref": "#/$defs/offset"
-				},
-				"delete_title": { "type": "string" },
-				"delete_origin": {
-					"$ref": "#/$defs/origin"
-				},
-				"delete_offset": {
-					"$ref": "#/$defs/offset"
-				},
 				"filter_title": { "type": "string" },
 				"filter_origin": {
 					"$ref": "#/$defs/origin"
@@ -206,22 +195,44 @@
 				},
 				"shell_offset": {
 					"$ref": "#/$defs/offset"
-				},
-				"overwrite_title": { "type": "string" },
-				"overwrite_origin": {
-					"$ref": "#/$defs/origin"
-				},
-				"overwrite_offset": {
-					"$ref": "#/$defs/offset"
-				},
-				"quit_title": { "type": "string" },
-				"quit_origin": {
-					"$ref": "#/$defs/origin"
-				},
-				"quit_offset": {
-					"$ref": "#/$defs/offset"
 				}
 			}
+		},
+		"confirm": {
+			"type": "object",
+			"properties": {
+				"trash_title": { "type": "string" },
+				"trash_origin": {
+					 "$ref": "#/$defs/origin"
+				},
+				"trash_offset": { 
+					"$ref": "#/$defs/offset" 
+				},
+				"delete_title": { "type": "string" },
+				"delete_origin": { 
+					"$ref": "#/$defs/origin"
+				},
+				"delete_offset": { 
+					"$ref": "#/$defs/offset" 
+				},
+				"overwrite_title": { "type": "string" },
+				"overwrite_content": { "type": "string" },
+				"overwrite_origin": {
+					"$ref": "#/$defs/origin" 
+				},
+				"overwrite_offset": { 
+					"$ref": "#/$defs/offset"
+			  },
+				"quit_title": { "type": "string" },
+				"quit_content": { "type": "string" },
+				"quit_origin": { 
+					"$ref": "#/$defs/origin" 
+				},
+				"quit_offset": { 
+					"$ref": "#/$defs/offset" 
+				}
+			},
+			"additionalProperties": false
 		},
 		"select": {
 			"type": "object",


### PR DESCRIPTION
This issue is detected after I  installed a new vs code extension called [Even Better Toml](https://marketplace.cursorapi.com/items?itemName=tamasfe.even-better-toml)
Recently there are a few commits in https://github.com/sxyazi/yazi, (including this one https://github.com/sxyazi/yazi/commit/92112de1c05c288c631f669523fc40fd4eb709d2) 
adding some new properties like `confirm` ,`title_format` and `image_delay`, which should be sync up to validation schema as well.

This PR has passed this  validation `npm run lint ` 