### PR TITLE
fix(schemas/yazi.json): `preview.ueberzug_offset` has no restrictions

### DIFF
--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -75,8 +75,7 @@
 					"type": "array",
 					"items": {
 						"type": "number",
-						"minimum": 0,
-						"maximum": 1
+						"minimum": 0
 					},
 					"minItems": 4,
 					"maxItems": 4

--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -73,10 +73,7 @@
 				"ueberzug_scale": { "type": "number", "minimum": 0 },
 				"ueberzug_offset": {
 					"type": "array",
-					"items": {
-						"type": "number",
-						"minimum": 0
-					},
+					"items": { "type": "number" },
 					"minItems": 4,
 					"maxItems": 4
 				}


### PR DESCRIPTION
`ueberzug_offset ([x, y, width, height])`: Ueberzug image offset, in cell units. It doesn't need to be less than 1.