### PR TITLE
fix(schemas/yazi.json): update `$defs/offset`

### DIFF
--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -291,9 +291,12 @@
 		},
 		"offset": {
 			"type": "array",
-			"items": {
-				"$ref": "/schemas/types/u16.json"
-			},
+			"items": [
+				{ "type": "integer", "minimum": -32768, "maximum": 32767 },
+				{ "type": "integer", "minimum": -32768, "maximum": 32767 },
+				{ "type": "integer", "minimum": 0, "maximum": 32767 },
+				{ "type": "integer", "minimum": 3, "maximum": 32767 }
+			],
 			"minItems": 4,
 			"maxItems": 4
 		},


### PR DESCRIPTION
offset (x, y, width, height) only allows the following ranges:
- -32768 ≤ x ≤ 32767
- -32768 ≤ y ≤ 32767
- 0 ≤ width ≤ 32767
- 3 ≤ 32767 ≤ 32767

maybe consider adding `i16` type to simplify these