### PR TITLE
fix(schemas/yazi.json): set minimum of 3 for offset height

### DIFF
--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -294,8 +294,8 @@
 			"items": [
 				{ "$ref": "/schemas/types/i16.json" },
 				{ "$ref": "/schemas/types/i16.json" },
-				{ "$ref": "/schemas/types/u16.json", "minimum": 0 },
-				{ "$ref": "/schemas/types/u16.json", "minimum": 3  }
+				{ "$ref": "/schemas/types/u16.json" },
+				{ "type": "integer", "minimum": 3 , "maximum": 65535 }
 			],
 			"minItems": 4,
 			"maxItems": 4


### PR DESCRIPTION
@AminurAlam I think we can't use a reference to a type and override fields like min/max from that type at the same time. I've removed the minimum of 0 on the 3rd item in the offset since that is the default for u16, and then for the fourth item / offset height I switched off using u16 entirely and just manually set the max to the u16 max value. This now appears to properly fail if the height offset is below 3.