### PR TITLE
chore: bump pnpm from 10.0.0-beta.2 to 10.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,5 @@
 	"devDependencies": {
 		"prettier": "^3.4.2"
 	},
-	"packageManager": "pnpm@10.0.0-beta.2+sha512.d219a39dda2e29a05cc721cb9e31483a79c7b49ffafa8001a25f74ac8c0bb7eea2f2b3f415dc3b65a3a0443acff389f1058ec0efa84e7fdf420684b626004b2a"
+	"packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }


### PR DESCRIPTION
Hi, I noticed pnpm is currently a beta version from last Christmas. Although the effect is probably nothing, I figured it could be bumped to the latest stable version.