### PR TITLE
ci: remove needless `--frozen-lockfile` from workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Test
         run: pnpm run test


### PR DESCRIPTION
pnpm uses `--frozen-lockfile` by default, so it does nothing. It was also removed in https://github.com/pnpm/action-setup/issues/168