### PR TITLE
feat(schemas/yazi.json): support `files` and `files.excludes`

### DIFF
--- a/schemas/yazi.json
+++ b/schemas/yazi.json
@@ -56,6 +56,25 @@
 			},
 			"additionalProperties": false
 		},
+		"files": {
+			"type": "object",
+			"properties": {
+				"excludes": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"urn": { "type": "string" },
+							"in": { "type": "string" },
+							"desc": { "type": "string" }
+						},
+						"required": ["urn", "in"],
+						"additionalProperties": false
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"preview": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
This pull request adds a new `files` section to the `schemas/yazi.json` schema, allowing for more precise configuration of file exclusions. The new section enables specifying files to exclude using their URN and location, with optional descriptions.

**Schema extension for file exclusions:**

* Added a new `files` object to the schema, which contains an `excludes` array for specifying excluded files with `urn`, `in`, and optional `desc` properties.

This update follows the changes from https://github.com/sxyazi/yazi/pull/3266