### PR TITLE
fix(schemas/theme.json): url for icon globs

### DIFF
--- a/schemas/theme.json
+++ b/schemas/theme.json
@@ -272,9 +272,9 @@
 		"icon": {
 			"type": "object",
 			"properties": {
-				"globs": { "$ref": "#/$defs/icon_rules" },
-				"prepend_globs": { "$ref": "#/$defs/icon_rules" },
-				"append_globs": { "$ref": "#/$defs/icon_rules" },
+				"globs": { "$ref": "#/$defs/glob_rules" },
+				"prepend_globs": { "$ref": "#/$defs/glob_rules" },
+				"append_globs": { "$ref": "#/$defs/glob_rules" },
 				"dirs": { "$ref": "#/$defs/icon_rules" },
 				"prepend_dirs": { "$ref": "#/$defs/icon_rules" },
 				"append_dirs": { "$ref": "#/$defs/icon_rules" },
@@ -335,6 +335,18 @@
 				"reversed": { "type": "boolean" },
 				"hidden": { "type": "boolean" },
 				"crossed": { "type": "boolean" }
+			}
+		},
+		"glob_rules": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"url": { "type": "string" },
+					"text": { "type": "string" },
+					"fg": { "$ref": "#/$defs/color" }
+				},
+				"required": ["url", "text"]
 			}
 		},
 		"icon_rules": {


### PR DESCRIPTION
https://yazi-rs.github.io/docs/configuration/theme/#icon
> 1. globs: glob expressions, e.g., { url = "**/Downloads/*.zip", ... }
> 2. dirs: directory names, e.g., { name = "Desktop", ... }


`glob` requires url, not like `dirs`, `files`, `exts`. 
